### PR TITLE
Feat #15 ad slot serving api

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,7 +31,7 @@ function App() {
           <Route path="/myads" element={<MyadsAdvertiser />} />
           <Route path="/myslots" element={<MyslotsMedia />} />
           <Route path="/Local" element={<Local />} />
-          <Route path="/ad-serving" element={<AdServingPage />} />
+          <Route path="/ad-serving/:adId" element={<AdServingPage />} />
           <Route path="/ad-bid" element={<AdBidPage />} />
           <Route path="/adinfo/:adslotid" element={<Adinfo />} />
           <Route path="/ad-registration" element={<AdRegistration />} />

--- a/src/api/adServing.js
+++ b/src/api/adServing.js
@@ -10,3 +10,6 @@ export const getAdSlotInfo = (adslotId, type) =>
 // 광고자리별 입찰/노출 내역 조회
 export const getSlotServingDetail = (adslotId) =>
   api.get(`/ads/adslot/${adslotId}`);
+
+// 광고 노출 목록 조회
+export const getMyAdDetail = (adId) => api.get(`/ads/my/ad/${adId}`);

--- a/src/api/adServing.js
+++ b/src/api/adServing.js
@@ -6,3 +6,7 @@ export const getAdServingList = (adid) => api.get('/ad-serving', { adid });
 // 광고자리 상세 정보 조회 (week/month)
 export const getAdSlotInfo = (adslotId, type) =>
   api.get(`/ads/adslot/infor/${adslotId}`, { params: { type } });
+
+// 광고자리별 입찰/노출 내역 조회
+export const getSlotServingDetail = (adslotId) =>
+  api.get(`/ads/adslot/${adslotId}`);

--- a/src/pages/AdServingPage.jsx
+++ b/src/pages/AdServingPage.jsx
@@ -3,7 +3,7 @@ import Header from '../components/Header';
 import InfoBox from '../components/InfoBox';
 import AdServingTableHeader from '../components/AdServingTableHeader';
 import AdServingTableRow from '../components/AdServingTableRow';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import myads from '../data/bid';
 import ads from '../data/ads';
 import adslots from '../data/adslots';
@@ -12,9 +12,7 @@ import left_arrow from '../assets/left-arrow.png';
 import right_arrow from '../assets/right-arrow.png';
 
 function AdServingPage() {
-  const location = useLocation();
-  const query = new URLSearchParams(location.search);
-  const adId = query.get('adId');
+  const { adId } = useParams();
   const navigate = useNavigate();
 
   // 광고 정보

--- a/src/pages/AdServingPage.jsx
+++ b/src/pages/AdServingPage.jsx
@@ -3,7 +3,7 @@ import Header from '../components/Header';
 import InfoBox from '../components/InfoBox';
 import AdServingTableHeader from '../components/AdServingTableHeader';
 import AdServingTableRow from '../components/AdServingTableRow';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import ads from '../data/ads';
 import adslots from '../data/adslots';
 import dropdown_icon from '../assets/icon-dropdown.png';
@@ -14,7 +14,6 @@ import { getMyAdDetail } from '../api/adServing';
 function AdServingPage() {
   const { adId } = useParams();
   const navigate = useNavigate();
-
 
   const [myAdDetail, setMyAdDetail] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -52,7 +51,6 @@ function AdServingPage() {
     myAdDetail && myAdDetail.slotList
       ? Array.from(new Set(myAdDetail.slotList.map((slot) => slot.adSlotName)))
       : [];
-
 
   // 지출대비 노출점수(임의: 평균 노출점수 / 평균 입찰가)
   const avgScore =
@@ -191,12 +189,6 @@ function AdServingPage() {
 
   // 테이블 컬럼 정의
   const columns = ['광고자리명', '상태', '입찰가', '노출일시'];
-
-  // placeList: 광고자리명 목록 (API 데이터 기반)
-  const placeList =
-    myAdDetail && myAdDetail.slotList
-      ? Array.from(new Set(myAdDetail.slotList.map((slot) => slot.adSlotName)))
-      : [];
 
   return (
     <>


### PR DESCRIPTION
## 🌱 관련 이슈

- close : #16 

## 🌱 작업 사항

광고 입찰 목록 api 연결

## 🌱 참고 사항

수정사항

광고 노출 목록 api ( /ads/my/ad/{adId} )
광고 노출 목록 api에서 광고 자리 목록 줄 때 adSlotName이랑 adSlotId도 같이 줘야함.
입찰 상태 어떻게 되어있는지? 지금은 다 0으로 되어있음
지금 노출 일시가 안넘어옴

광고 낙찰 목록 ( /ads/adslot/{adslotId} )
"totalExposureHour": 0,
"exposureScore": 52.629586776859504

각각 총 노출 시간이랑 평균 노출 점수 맞는지?
